### PR TITLE
Bump ejs version to fix vulnerability for <3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"babel": "^5.8.38",
 				"deep-extend": "^0.5.1",
-				"ejs": "^3.1.6",
+				"ejs": "^3.1.9",
 				"loader-utils": "0.2.x",
 				"minimatch": "^3.0.3",
 				"slash": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	"dependencies": {
 	  "babel": "^5.8.38",
 	  "deep-extend": "^0.5.1",
-	  "ejs": "^3.1.6",
+	  "ejs": "^3.1.9",
 	  "loader-utils": "0.2.x",
 	  "minimatch": "^3.0.3",
 	  "slash": "^1.0.0"


### PR DESCRIPTION
Updating dependency due to critical vulnerability as reported in https://financialtimes.atlassian.net/browse/AT-5921

ejs bumped to latest version 3.9

[META](https://financialtimes.atlassian.net/browse/AT-5921) 